### PR TITLE
Refactor TimeMachine to take vararg Nodes

### DIFF
--- a/src/main/kotlin/TimeMachine.kt
+++ b/src/main/kotlin/TimeMachine.kt
@@ -1,7 +1,6 @@
 package org.example
 
-// TODO Make this take vararg of Nodes
-data class TimeMachine(val network: Network, val nodeA: Node, val nodeB: Node, val nodeC: Node? = null) {
+class TimeMachine(val network: Network, vararg val nodes: Node) {
     /**
      * The Network must come first, as the Nodes rely on its clock when they tick
      * E.g. NodeA sends to NodeB on tick 0, the earliest this message will arrive
@@ -9,14 +8,19 @@ data class TimeMachine(val network: Network, val nodeA: Node, val nodeB: Node, v
      *      still be on tick 0. If we tick the network first, we move to tick 1, and
      *      then when NodeB ticks, it will be on tick 1.
      */
+
     fun tick(): TimeMachine {
-        return this.copy(
+        return TimeMachine(
             network = network.tick(),
-            nodeA = nodeA.tick(),
-            nodeB = nodeB.tick(),
-            nodeC = nodeC?.tick()
+            *nodes.map(Node::tick).toTypedArray()
         )
     }
 
+
     fun tick(count: Int): TimeMachine = (0..count).fold(this) { acc, _ -> acc.tick() }
+    operator fun component1(): Network = network
+    operator fun component2(): Node = nodes[0]
+    operator fun component3(): Node = nodes[1]
+    operator fun component4(): Node = nodes[2]
+    operator fun component5(): Node = nodes[3]
 }


### PR DESCRIPTION
In kotlin, varargs are not allowed in data class constructors so TimeMachine has to become a regular class.

This means we lose the builtin `componentN()` methods that data classes provide which we use for destructuring, so I've introduced those up to `n = 5`. This is the same number as the builtin `List` provides, and felt like a sensible limit for destructuring.