### PR TITLE
Tiny type for addresses

### DIFF
--- a/src/main/kotlin/Candidate.kt
+++ b/src/main/kotlin/Candidate.kt
@@ -1,11 +1,11 @@
 package org.example
 
 data class Candidate(
-    override val address: Address,
+    override val address: Source,
     override val name: String,
     override val state: Int = 0,
     override val network: Network,
-    override val peers: List<Address>,
+    override val peers: List<Destination>,
     override val received: List<MessageLogEntry> = emptyList(),
     override val sent: List<MessageLogEntry> = emptyList(),
     override val config: Config = Config(),

--- a/src/main/kotlin/Follower.kt
+++ b/src/main/kotlin/Follower.kt
@@ -1,11 +1,11 @@
 package org.example
 
 data class Follower(
-    override val address: Address,
+    override val address: Source,
     override val name: String,
     override val state: Int = 0,
     override val network: Network,
-    override val peers: List<Address>,
+    override val peers: List<Destination>,
     override val received: List<MessageLogEntry> = emptyList(),
     override val sent: List<MessageLogEntry> = emptyList(),
     override val config: Config = Config(),
@@ -14,7 +14,7 @@ data class Follower(
     private fun process(state: Int, messages: List<Message>, message: Message): Pair<Int, List<Message>> {
         return when(message) {
             is Heartbeat -> ((state + message.content.toInt()) to messages)
-            is RequestForVotes -> (state to (if (shouldVote(messages)) messages + VoteFromFollower(address, message.src, "VOTE FROM FOLLOWER") else messages))
+            is RequestForVotes -> (state to (if (shouldVote(messages)) messages + VoteFromFollower(address, Destination.from(message.src), "VOTE FROM FOLLOWER") else messages))
             is VoteFromFollower -> (state to messages)
         }
     }

--- a/src/main/kotlin/Leader.kt
+++ b/src/main/kotlin/Leader.kt
@@ -1,11 +1,11 @@
 package org.example
 
 data class Leader(
-    override val address: Address,
+    override val address: Source,
     override val name: String,
     override val state: Int = 0,
     override val network: Network,
-    override val peers: List<Address>,
+    override val peers: List<Destination>,
     override val received: List<MessageLogEntry> = emptyList(),
     override val sent: List<MessageLogEntry> = emptyList(),
     override val config: Config = Config(),

--- a/src/main/kotlin/Network.kt
+++ b/src/main/kotlin/Network.kt
@@ -7,16 +7,23 @@ data class NetworkMessage(val message: Message, val deliveryTime: DeliveryTime)
 
 class Network(initialMessages: Map<Address, List<NetworkMessage>> = emptyMap()) {
     var clock = 0
-    private val messages = initialMessages.toMutableMap()
+
+    //TODO Write an ADR
+    // The keys are a Pair because we want to use the Host and Port to get the messages. This is because
+    // Address now has specialised types (Source and Destination) and even tho they have the same values
+    // they are compared differently so the messages were not returned
+    // This is to not break the contract of hashcode and equals
+    private val messages = initialMessages.mapKeys { it.key.host to it.key.port }.toMutableMap()
 
     fun get(address: Address): List<Message> {
+        val hostAndPort = address.host to address.port
         // get all messages for address with 0 delay and store
-        val (messagesToDeliver, remaining) = messages[address]
+        val (messagesToDeliver, remaining) = messages[hostAndPort]
             ?.partition { (_, deliveryTime) ->
                 deliveryTime <= clock
             } ?: (listOf<NetworkMessage>() to listOf())
 
-        messages[address] = remaining
+        messages[hostAndPort] = remaining
 
         // return store messages
         return messagesToDeliver.map { it.message }
@@ -24,7 +31,7 @@ class Network(initialMessages: Map<Address, List<NetworkMessage>> = emptyMap()) 
 
     fun add(message: Message, delay: NetworkDelay = 0) {
         val networkMessage = NetworkMessage(message, clock + 1 + delay)
-        messages[message.dest] = messages[message.dest]?.plus(networkMessage) ?: listOf(networkMessage)
+        messages[message.dest.host to message.dest.port] = messages[message.dest.host to message.dest.port]?.plus(networkMessage) ?: listOf(networkMessage)
     }
 
     fun tick(ticks: Int = 1): Network {

--- a/src/main/kotlin/Node.kt
+++ b/src/main/kotlin/Node.kt
@@ -6,14 +6,36 @@ data class Config(val electionTimeout: Int = 3)
 typealias ReceivedAt = Int //TODO Make this a Comparable, so when we change it to a 'Date' type for the real world, we do not need to change the usages
 typealias MessageLogEntry = Pair<ReceivedAt, Message> // TODO Make a real class with named props
 
-data class Address(val host: String, val port: Int)
 
+sealed class Address(open val host: String, open val port: Int)
+data class Source(override val host: String, override val port: Int) : Address(host, port) {
+    companion object {
+        fun from(dest: Destination) : Source {
+            return Source(dest.host, dest.port)
+        }
+
+        fun from(dest: List<Destination>) : List<Source> {
+            return dest.map { it -> Source(it.host, it.port) }
+        }
+    }
+}
+data class Destination(override val host: String, override val port: Int) : Address(host, port) {
+    companion object {
+        fun from(src: Address) : Destination {
+            return Destination(src.host, src.port)
+        }
+
+        fun from(src: List<Source>) : List<Destination> {
+            return src.map { it -> Destination(it.host, it.port) }
+        }
+    }
+}
 
 // TODO add tiny type Source and Destination
-sealed class Message(open val src: Address, open val dest: Address, open val content: String) //TODO remove 'content' from the Message and add it to the subclasses if we have one type of Message without 'content'
-data class RequestForVotes(override val src: Address, override val dest: Address, override val content: String) : Message(src, dest, content)
-data class VoteFromFollower(override val src: Address, override val dest: Address, override val content: String) : Message(src, dest, content)
-data class Heartbeat(override val src: Address, override val dest: Address, override val content: String) : Message(src, dest, content)
+sealed class Message(open val src: Source, open val dest: Destination, open val content: String) //TODO remove 'content' from the Message and add it to the subclasses if we have one type of Message without 'content'
+data class RequestForVotes(override val src: Source, override val dest: Destination, override val content: String) : Message(src, dest, content)
+data class VoteFromFollower(override val src: Source, override val dest: Destination, override val content: String) : Message(src, dest, content)
+data class Heartbeat(override val src: Source, override val dest: Destination, override val content: String) : Message(src, dest, content)
 // TODO We need to make these generic, and AppendEntries content should be List<T> - find a way to do this with generics, or remove the parent content
 //data class AppendEntries(override val src: Address, override val dest: Address, override val content: String) : Message(src, dest, content)
 
@@ -23,7 +45,7 @@ abstract class Node(
     open val name: String,
     open val state: Int,
     open val network: Network,
-    open val peers: List<Address>,
+    open val peers: List<Destination>,
     open val received: List<MessageLogEntry> = emptyList(),
     open val sent: List<MessageLogEntry> = emptyList(), //TODO create a different type for sent and received
     open val config: Config = Config(),

--- a/src/test/kotlin/CandidateTest.kt
+++ b/src/test/kotlin/CandidateTest.kt
@@ -1,6 +1,8 @@
 import org.example.Address
 import org.example.Candidate
+import org.example.Destination
 import org.example.Network
+import org.example.Source
 import org.example.VoteFromFollower
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,13 +21,13 @@ class CandidateTest {
         val candidate = candidate()
 
         val messageLog = listOf(
-            0 to VoteFromFollower(Address("host1", 1), Address("host0", 1), "Vote"),
-            0 to VoteFromFollower(Address("host2", 1), Address("host0", 1), "Vote")
+            0 to VoteFromFollower(Source("host1", 1), Destination("host0", 1), "Vote"),
+            0 to VoteFromFollower(Source("host2", 1), Destination("host0", 1), "Vote")
         )
         assertTrue(candidate.shouldBecomeLeader(messageLog))
     }
 
     fun candidate(): Candidate {
-        return Candidate(Address("host", 1), "name", 0, Network(), listOf(Address("host1", 1), Address("host2", 1), Address("host2", 1)))
+        return Candidate(Source("host", 1), "name", 0, Network(), listOf(Destination("host1", 1), Destination("host2", 1), Destination("host2", 1)))
     }
 }

--- a/src/test/kotlin/FollowerTest.kt
+++ b/src/test/kotlin/FollowerTest.kt
@@ -22,7 +22,6 @@ class FollowerTest {
         val timeMachine = TimeMachine(network, Follower(Source("host", 1), "follower", 0, network, emptyList(), emptyList()))
         val (_, follower) = timeMachine.tick()
 
-        //TODO COULD BE THAT THE ADDRESSES ARE WRONG
         assertEquals(listOf((1 to VoteFromFollower(Source("host", 1), Destination("host", 2), "VOTE FROM FOLLOWER"))), follower.sent)
     }
 }

--- a/src/test/kotlin/FollowerTest.kt
+++ b/src/test/kotlin/FollowerTest.kt
@@ -1,8 +1,10 @@
 import org.example.Address
+import org.example.Destination
 import org.example.Follower
 import org.example.Network
 import org.example.NetworkMessage
 import org.example.RequestForVotes
+import org.example.Source
 import org.example.TimeMachine
 import org.example.VoteFromFollower
 import org.junit.jupiter.api.Assertions.*
@@ -11,16 +13,16 @@ import org.junit.jupiter.api.Test
 class FollowerTest {
     @Test
     fun `Do not vote for more than one Candidate`() {
-        val network = Network(mapOf(Address("host", 1) to listOf(
-            NetworkMessage(RequestForVotes(Address("host", 2), Address("host", 1), "REQUEST FOR VOTES"), 0),
-            NetworkMessage(RequestForVotes(Address("host", 3), Address("host", 1), "REQUEST FOR VOTES"), 0)
+        val network = Network(mapOf(Source("host", 1) to listOf(
+            NetworkMessage(RequestForVotes(Source("host", 2), Destination("host", 1), "REQUEST FOR VOTES"), 0),
+            NetworkMessage(RequestForVotes(Source("host", 3), Destination("host", 1), "REQUEST FOR VOTES"), 0)
         )))
 
         //TODO Write an ADR on why use time machine instead of tick on the Node and Network and why the Network is mutable
-        val timeMachine = TimeMachine(network, Follower(Address("host", 1), "follower", 0, network, emptyList(), emptyList()))
+        val timeMachine = TimeMachine(network, Follower(Source("host", 1), "follower", 0, network, emptyList(), emptyList()))
         val (_, follower) = timeMachine.tick()
 
         //TODO COULD BE THAT THE ADDRESSES ARE WRONG
-        assertEquals(listOf((1 to VoteFromFollower(Address("host", 1), Address("host", 2), "VOTE FROM FOLLOWER"))), follower.sent)
+        assertEquals(listOf((1 to VoteFromFollower(Source("host", 1), Destination("host", 2), "VOTE FROM FOLLOWER"))), follower.sent)
     }
 }

--- a/src/test/kotlin/NetworkTests.kt
+++ b/src/test/kotlin/NetworkTests.kt
@@ -1,7 +1,9 @@
 import org.example.Address
+import org.example.Destination
 import org.example.Heartbeat
 import org.example.Network
 import org.example.NetworkMessage
+import org.example.Source
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -10,9 +12,9 @@ class NetworkTests {
     @Test
     fun `Given a message, delivers it when the network tick matches the deliver time`() {
         // Given
-        val source = Address("127.0.0.1", 8000)
-        val destination = Address("127.0.0.1", 8001)
-        val initialMessages = mapOf(
+        val source = Source("127.0.0.1", 8000)
+        val destination = Destination("127.0.0.1", 8001)
+        val initialMessages = mapOf<Address, List<NetworkMessage>>(
             destination to listOf(
                 NetworkMessage(Heartbeat(source, destination, "A"), 1),
                 NetworkMessage(Heartbeat(source, destination, "A"), 2)
@@ -32,9 +34,9 @@ class NetworkTests {
     @Test
     fun `Deliver all the messages that delivery time is at or behind the network clock`() {
         // Given
-        val source = Address("127.0.0.1", 8000)
-        val destination = Address("127.0.0.1", 8001)
-        val initialMessages = mapOf(
+        val source = Source("127.0.0.1", 8000)
+        val destination = Destination("127.0.0.1", 8001)
+        val initialMessages = mapOf<Address, List<NetworkMessage>>(
             destination to listOf(
                 NetworkMessage(Heartbeat(source, destination, "A"), 1),
                 NetworkMessage(Heartbeat(source, destination, "B"), 2)
@@ -57,8 +59,8 @@ class NetworkTests {
     @Test
     fun `Adding a message to the network with delay 0, the message will be delivered at the next tick`() {
         // Given
-        val source = Address("127.0.0.1", 8000)
-        val destination = Address("127.0.0.1", 8001)
+        val source = Source("127.0.0.1", 8000)
+        val destination = Destination("127.0.0.1", 8001)
 
         val network = Network()
         network.tick()
@@ -77,8 +79,8 @@ class NetworkTests {
     @Test
     fun `Messages for previous ticks are delivered on the next network time`() {
         // Given
-        val source = Address("127.0.0.1", 8000)
-        val destination = Address("127.0.0.1", 8001)
+        val source = Source("127.0.0.1", 8000)
+        val destination = Destination("127.0.0.1", 8001)
 
         val network = Network()
         network.add(Heartbeat(source, destination, "A"), 0)

--- a/src/test/kotlin/NodeTests.kt
+++ b/src/test/kotlin/NodeTests.kt
@@ -1,8 +1,10 @@
 import org.example.Address
 import org.example.Candidate
+import org.example.Destination
 import org.example.Follower
 import org.example.Heartbeat
 import org.example.Network
+import org.example.Source
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -13,13 +15,13 @@ class NodeTests {
         // Given
         val network = Network()
 
-        val nodeBAddress = Address("127.0.0.1", 9002)
+        val nodeBAddress = Source("127.0.0.1", 9002)
         val nodeB = Follower(nodeBAddress, "NodeB", network = network, peers = emptyList())
 
-        val nodeA = Follower(Address("127.0.0.1", 9001), "NodeA", network = network, peers = listOf(nodeBAddress))
+        val nodeA = Follower(Source("127.0.0.1", 9001), "NodeA", network = network, peers = listOf(Destination.from(nodeBAddress)))
 
         // When
-        nodeA.send(Heartbeat(nodeA.address, nodeB.address, "1"))
+        nodeA.send(Heartbeat(nodeA.address, Destination.from(nodeB.address), "1"))
         network.tick()
         val newNodeB = nodeB.tick()
 
@@ -31,7 +33,7 @@ class NodeTests {
     fun `Follower becomes a Candidate if it does not receive a heartbeat before the election timeout (3 ticks)`() {
         // Given
         val network = Network()
-        val follower = Follower(Address("127.0.0.1", 9001), "NodeA", network = network, peers = emptyList())
+        val follower = Follower(Source("127.0.0.1", 9001), "NodeA", network = network, peers = emptyList())
 
         // When
         network.tick()
@@ -54,8 +56,8 @@ class NodeTests {
     fun `A Request for Votes is sent when a Follower Becomes a Candidate (timeout 3 ticks)`() {
         // Given
         val network = Network()
-        val destination = Address("127.0.0.1", 9002)
-        val follower = Follower(Address("127.0.0.1", 9001), "NodeA", network = network, peers = listOf(destination))
+        val destination = Destination("127.0.0.1", 9002)
+        val follower = Follower(Source("127.0.0.1", 9001), "NodeA", network = network, peers = listOf(destination))
 
         // When
         network.tick()

--- a/src/test/kotlin/usecases/ElectionTest.kt
+++ b/src/test/kotlin/usecases/ElectionTest.kt
@@ -3,11 +3,13 @@ package usecases
 import org.example.Address
 import org.example.Candidate
 import org.example.Config
+import org.example.Destination
 import org.example.Follower
 import org.example.Heartbeat
 import org.example.Leader
 import org.example.Network
 import org.example.RequestForVotes
+import org.example.Source
 import org.example.TimeMachine
 import org.example.VoteFromFollower
 import org.junit.jupiter.api.Test
@@ -22,11 +24,11 @@ class ElectionTest {
         // Given
         val network = Network()
 
-        val willPromoteAddress = Address("127.0.0.1", 9001)
-        val remainsFollowerAddress = Address("127.0.0.1", 9002)
+        val willPromoteAddress = Source("127.0.0.1", 9001)
+        val remainsFollowerAddress = Source("127.0.0.1", 9002)
 
-        val willPromote = Follower(willPromoteAddress, "NodeA", network = network, peers = listOf(remainsFollowerAddress), config = Config(3))
-        val remainsFollower = Follower(remainsFollowerAddress, "NodeA", network = network, peers = listOf(remainsFollowerAddress), config = Config(10))
+        val willPromote = Follower(willPromoteAddress, "NodeA", network = network, peers = listOf(Destination.from(remainsFollowerAddress)), config = Config(3))
+        val remainsFollower = Follower(remainsFollowerAddress, "NodeA", network = network, peers = Destination.from(listOf(remainsFollowerAddress)), config = Config(10))
 
         // When
         val timeMachine = TimeMachine(network, willPromote, remainsFollower).tick(4)
@@ -48,13 +50,14 @@ class ElectionTest {
         // Given
         val network = Network()
 
-        val willBecomeLeaderAddress = Address("127.0.0.1", 9001)
-        val willLoseElectionAddress = Address("127.0.0.1", 9002)
-        val remainsFollowerAddress = Address("127.0.0.1", 9003)
+        val willBecomeLeaderAddress = Source("127.0.0.1", 9001)
+        val willLoseElectionAddress = Source("127.0.0.1", 9002)
+        val remainsFollowerAddress = Source("127.0.0.1", 9003)
 
-        val willBecomeLeader = Follower(willBecomeLeaderAddress, "NodeA", network = network, peers = listOf(willLoseElectionAddress, remainsFollowerAddress), config = Config(3))
-        val willLoseElection = Follower(willLoseElectionAddress, "NodeB", network = network, peers = listOf(willBecomeLeaderAddress, remainsFollowerAddress), config = Config(3))
-        val remainsFollower = Follower(remainsFollowerAddress, "NodeC", network = network, peers = listOf(willBecomeLeaderAddress, willLoseElectionAddress), config = Config(10))
+
+        val willBecomeLeader = Follower(willBecomeLeaderAddress, "NodeA", network = network, peers = Destination.from(listOf(willLoseElectionAddress, remainsFollowerAddress)), config = Config(3))
+        val willLoseElection = Follower(willLoseElectionAddress, "NodeB", network = network, peers = Destination.from(listOf(willBecomeLeaderAddress, remainsFollowerAddress)), config = Config(3))
+        val remainsFollower = Follower(remainsFollowerAddress, "NodeC", network = network, peers = Destination.from(listOf(willBecomeLeaderAddress, willLoseElectionAddress)), config = Config(10))
 
         // When
         val timeMachine = TimeMachine(network, willBecomeLeader, willLoseElection, remainsFollower).tick(4)
@@ -84,8 +87,8 @@ class ElectionTest {
         val (_, _, follower1, follower2) = timeMachine.tick()
         // Candidate has been demoted to Follower
         assertIs<Follower>(follower1)
-        assertEquals(Heartbeat(willBecomeLeaderAddress, follower1.address, "0"), follower1.received.last().second)
-        assertEquals(Heartbeat(willBecomeLeaderAddress, follower2.address, "0"), follower2.received.last().second)
+        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower1.address), "0"), follower1.received.last().second)
+        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower2.address), "0"), follower2.received.last().second)
     }
 
 }


### PR DESCRIPTION
Use tiny types for the Address, differentiating between
Source and Destination.

This causes a small bug not allowing to retrieve messages from the
Network when the Host and Port are the same but the type of the Address
is different.

It was considered to override the Hashcode and Equals to consider only
the data and not the type but that would break the contract of the language.
A more appropritated solution will be to use the Host and Port as keys
for the messages on the Network instead of the Address itself, to be fixed on the next commit.

----------

Network uses Host and Port to retrieve the messages.

Using the Address as a key to retrieve the messages do not work
anymore as we are using to specialised types to differentiate the
Addresses (Source and Destination). Even if the types have the same
values (host and port) they are still considered different objects.

Instead of breaking the language contract of the 'equals and hashcode'
we use the Host and Port as a combined key to retrieve the messages.