### PR TITLE
Use state machine methods to promote / demote Nodes

### DIFF
--- a/src/main/kotlin/Follower.kt
+++ b/src/main/kotlin/Follower.kt
@@ -6,6 +6,7 @@ data class Follower(
     override val state: Int = 0,
     override val network: Network,
     override val peers: List<Destination>,
+    //TODO Encapsulate collections "Received" and "Sent"
     override val received: List<MessageLogEntry> = emptyList(),
     override val sent: List<MessageLogEntry> = emptyList(),
     override val config: Config = Config(),
@@ -29,16 +30,16 @@ data class Follower(
         messagesToSend.forEach { send(it) } // TODO remove side effect
 
         val messageLog = received + tickMessages.map { network.clock to it }
+        val newSent = sent + messagesToSend.map { network.clock to it }
 
         if (shouldPromote(messageLog)) {
-            // TODO Move this to a Candidate constructor that takes a Follower
-            //      Also, when creating a candidate, add a 'VoteFromFollower' from self to received messageLog
-            val candidate = Candidate(address, name, state, network, peers, messageLog, sent = sent + messagesToSend.map { network.clock to it })
+            // TODO when creating a candidate (promoting a follower), add a 'VoteFromFollower' from self to received messageLogMove this to a Candidate constructor that takes a Follower
+            val candidate = promote(messageLog, newSent)
             peers.forEach { peer -> candidate.send(RequestForVotes(this.address, peer, "REQUEST FOR VOTES")) } // TODO Refactor to return the messages to be sent instead of a side effect
             return candidate
         }
 
-         return this.copy(state = newState, received = messageLog, sent = sent + messagesToSend.map { network.clock to it })
+         return this.copy(state = newState, received = messageLog, sent = newSent)
     }
 
     //TODO UNIT TEST
@@ -54,7 +55,12 @@ data class Follower(
         TODO("Not yet implemented")
     }
 
+    //TODO unit test
     fun shouldVote(tickMessages: List<Message>): Boolean {
         return (sent + tickMessages).filterIsInstance<VoteFromFollower>().isEmpty()
+    }
+
+    private fun promote(newReceived: List<MessageLogEntry>, newSent: List<MessageLogEntry>): Candidate {
+        return Candidate(this.address, this.name, this.state, this.network, this.peers, newReceived, newSent)
     }
 }

--- a/src/main/kotlin/Leader.kt
+++ b/src/main/kotlin/Leader.kt
@@ -1,5 +1,9 @@
 package org.example
 
+
+//TODO maybe we should make all the constructors except the Followe as private
+// this way all nodes can only be initialized as Follower and only transition to a new
+// state thought the state machine
 data class Leader(
     override val address: Source,
     override val name: String,
@@ -17,5 +21,4 @@ data class Leader(
     override fun receive(message: Message): Node {
         TODO("Not yet implemented")
     }
-
 }


### PR DESCRIPTION
State machine methods will help us to keep the transition between the Nodes' state consistent and conscise. We do not need to pass all the parameters that do not change on the transtion (as name, config, etc).