### PR TITLE
Replace MessageLogEntry with SentMessage and ReceivedMessage

### DIFF
--- a/src/main/kotlin/Leader.kt
+++ b/src/main/kotlin/Leader.kt
@@ -10,8 +10,8 @@ data class Leader(
     override val state: Int = 0,
     override val network: Network,
     override val peers: List<Destination>,
-    override val received: List<MessageLogEntry> = emptyList(),
-    override val sent: List<MessageLogEntry> = emptyList(),
+    override val received: List<ReceivedMessage> = emptyList(),
+    override val sent: List<SentMessage> = emptyList(),
     override val config: Config = Config(),
 ): Node(address, name, state, network, peers, received) {
     override fun tick(): Node {

--- a/src/main/kotlin/Node.kt
+++ b/src/main/kotlin/Node.kt
@@ -3,10 +3,6 @@ package org.example
 // TODO: Figure out a good type for this when we start cleaning
 data class Config(val electionTimeout: Int = 3)
 
-typealias ReceivedAt = Int //TODO Make this a Comparable, so when we change it to a 'Date' type for the real world, we do not need to change the usages
-typealias MessageLogEntry = Pair<ReceivedAt, Message> // TODO Make a real class with named props
-
-
 sealed class Address(open val host: String, open val port: Int)
 data class Source(override val host: String, override val port: Int) : Address(host, port) {
     companion object {
@@ -31,6 +27,11 @@ data class Destination(override val host: String, override val port: Int) : Addr
     }
 }
 
+typealias ReceivedAt = Int //TODO Make this a Comparable, so when we change it to a 'Date' type for the real world, we do not need to change the usages
+
+data class SentMessage(val message: Message, val sentAt: ReceivedAt)
+data class ReceivedMessage(val message: Message, val receivedAt: ReceivedAt)
+
 // TODO add tiny type Source and Destination
 sealed class Message(open val src: Source, open val dest: Destination, open val content: String) //TODO remove 'content' from the Message and add it to the subclasses if we have one type of Message without 'content'
 data class RequestForVotes(override val src: Source, override val dest: Destination, override val content: String) : Message(src, dest, content)
@@ -46,8 +47,8 @@ abstract class Node(
     open val state: Int,
     open val network: Network,
     open val peers: List<Destination>,
-    open val received: List<MessageLogEntry> = emptyList(),
-    open val sent: List<MessageLogEntry> = emptyList(), //TODO create a different type for sent and received
+    open val received: List<ReceivedMessage> = emptyList(),
+    open val sent: List<SentMessage> = emptyList(),
     open val config: Config = Config(),
 ) {
     fun tick(ticks: Int): Node {

--- a/src/test/kotlin/CandidateTest.kt
+++ b/src/test/kotlin/CandidateTest.kt
@@ -2,6 +2,7 @@ import org.example.Address
 import org.example.Candidate
 import org.example.Destination
 import org.example.Network
+import org.example.ReceivedMessage
 import org.example.Source
 import org.example.VoteFromFollower
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -21,8 +22,8 @@ class CandidateTest {
         val candidate = candidate()
 
         val messageLog = listOf(
-            0 to VoteFromFollower(Source("host1", 1), Destination("host0", 1), "Vote"),
-            0 to VoteFromFollower(Source("host2", 1), Destination("host0", 1), "Vote")
+            ReceivedMessage(VoteFromFollower(Source("host1", 1), Destination("host0", 1), "Vote"), 0),
+            ReceivedMessage(VoteFromFollower(Source("host2", 1), Destination("host0", 1), "Vote"), 0),
         )
         assertTrue(candidate.shouldBecomeLeader(messageLog))
     }

--- a/src/test/kotlin/FollowerTest.kt
+++ b/src/test/kotlin/FollowerTest.kt
@@ -1,9 +1,9 @@
-import org.example.Address
 import org.example.Destination
 import org.example.Follower
 import org.example.Network
 import org.example.NetworkMessage
 import org.example.RequestForVotes
+import org.example.SentMessage
 import org.example.Source
 import org.example.TimeMachine
 import org.example.VoteFromFollower
@@ -22,6 +22,6 @@ class FollowerTest {
         val timeMachine = TimeMachine(network, Follower(Source("host", 1), "follower", 0, network, emptyList(), emptyList()))
         val (_, follower) = timeMachine.tick()
 
-        assertEquals(listOf((1 to VoteFromFollower(Source("host", 1), Destination("host", 2), "VOTE FROM FOLLOWER"))), follower.sent)
+        assertEquals(listOf(SentMessage(VoteFromFollower(Source("host", 1), Destination("host", 2), "VOTE FROM FOLLOWER"), 1)), follower.sent)
     }
 }

--- a/src/test/kotlin/NodeTests.kt
+++ b/src/test/kotlin/NodeTests.kt
@@ -1,4 +1,3 @@
-import org.example.Address
 import org.example.Candidate
 import org.example.Destination
 import org.example.Follower

--- a/src/test/kotlin/usecases/ElectionTest.kt
+++ b/src/test/kotlin/usecases/ElectionTest.kt
@@ -1,6 +1,5 @@
 package usecases
 
-import org.example.Address
 import org.example.Candidate
 import org.example.Config
 import org.example.Destination
@@ -37,12 +36,12 @@ class ElectionTest {
         // Then Candidate got promoted and sent its Request for Votes to the Follower
         assertTrue(becameCandidate is Candidate)
         assertTrue(remainedFollower is Follower)
-        assertEquals("REQUEST FOR VOTES", remainedFollower.received.first().second.content)
+        assertEquals("REQUEST FOR VOTES", remainedFollower.received.first().message.content)
 
         val (_, leaderWithVote, _)= timeMachine.tick()
 
         assertTrue(leaderWithVote is Leader)
-        assertEquals("VOTE FROM FOLLOWER", leaderWithVote.received.first().second.content)
+        assertEquals("VOTE FROM FOLLOWER", leaderWithVote.received.first().message.content)
     }
 
     @Test
@@ -68,11 +67,11 @@ class ElectionTest {
         assertTrue(candidateWillLose is Candidate)
         assertTrue(follower is Follower)
 
-        val futureWinnerRequestForVotes = follower.received.first().second
+        val futureWinnerRequestForVotes = follower.received.first().message
         assertTrue(futureWinnerRequestForVotes is RequestForVotes)
         assertEquals(willBecomeLeaderAddress, futureWinnerRequestForVotes.src)
 
-        val futureLoserRequestForVotes = follower.received[1].second
+        val futureLoserRequestForVotes = follower.received[1].message
         assertTrue(futureLoserRequestForVotes is RequestForVotes)
         assertEquals(willLoseElectionAddress, futureLoserRequestForVotes.src)
 
@@ -80,15 +79,15 @@ class ElectionTest {
 
         // New leader is decided, other candidate will be demoted when it receives Heartbeat on the next tick
         assertIs<Leader>(leader)
-        assertTrue(leader.received.last().second is VoteFromFollower)
+        assertTrue(leader.received.last().message is VoteFromFollower)
         assertIs<Candidate>(candidateToBeDemoted)
 
         // TODO check that non-Leaders receive the Heartbeat from new Leader
         val (_, _, follower1, follower2) = timeMachine.tick()
         // Candidate has been demoted to Follower
         assertIs<Follower>(follower1)
-        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower1.address), "0"), follower1.received.last().second)
-        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower2.address), "0"), follower2.received.last().second)
+        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower1.address), "0"), follower1.received.last().message)
+        assertEquals(Heartbeat(willBecomeLeaderAddress, Destination.from(follower2.address), "0"), follower2.received.last().message)
     }
 
 }


### PR DESCRIPTION
To keep good type separation, two new classes are introduced so that received and sent lists on Node are incompatible. It also introduces named properties, meaning we don't need to access log entries with `first` and `second`.

For now we are keeping `ReceivedAt`, as the scope grew massively when trying to replace it with a Comparable type.