### PR TITLE
Process returns node

### DIFF
--- a/src/main/kotlin/Candidate.kt
+++ b/src/main/kotlin/Candidate.kt
@@ -14,12 +14,15 @@ data class Candidate(
     // TODO Make process return Node, so we have finer control over how we handle each message
     //      e.g. If a Candidate receives a Heartbeat, it should demote to follower, this is difficult
     //      with the current architecture. This would allow us to remove methods to demote/promote
-    private fun process(state: Int, messages: List<Message>, message: Message): Pair<Int, List<Message>> {
-        return when(message) {
-            is Heartbeat -> ((state + message.content.toInt()) to messages)
-            is RequestForVotes -> (state to messages)
-            is VoteFromFollower -> (state to messages)
+    override fun process(accumulatedToSend: List<Message>, received: Message): Pair<Node, List<Message>> {
+        val (n, newToSend) = when(received) {
+            is Heartbeat -> (this.copy(state = (state + received.content.toInt())) to emptyList<Message>())
+            is RequestForVotes -> (this to emptyList())
+            is VoteFromFollower -> (this to emptyList())
         }
+
+        val n2 = n.copy(received = n.received + ReceivedMessage(received, network.clock), sent = n.sent + newToSend.map { SentMessage(it, network.clock) } )
+        return n2 to accumulatedToSend + newToSend
     }
 
     override fun tick(): Node {
@@ -32,36 +35,37 @@ data class Candidate(
         //TODO We have this common logic in the Follower, move it to Node
         val tickMessages = network.get(this.address)
 
-        val (newState, messagesToSend) = tickMessages.fold(state to emptyList<Message>()) { (s, messages), msg ->
-            process(s, messages, msg)
+        val (node, messagesToSend) = tickMessages.fold(this as Node to emptyList<Message>()) { (n, messages), msg ->
+            n.process(messages, msg)
         }
 
-        val messageLog = received + tickMessages.map { ReceivedMessage(it, network.clock) }
-        val newSent = sent + messagesToSend.map { SentMessage(it, network.clock)}
-
-        if (shouldDemoteToFollower(messageLog)) {
-            return demote(newState, messageLog, newSent) to messagesToSend
+        val newNode = node as Candidate
+        if (node.shouldDemoteToFollower()) {
+            return node.demote() to messagesToSend
         }
 
-        if (shouldBecomeLeader(messageLog)) {
-            val leader = promote(newState, messageLog, newSent)
-            // TODO Refactor to return the messages to be sent instead of a side effect
-            peers.forEach { peer -> leader.send(Heartbeat( leader.address, peer, "0")) }
-            return leader to messagesToSend
+        if (node.shouldBecomeLeader()) {
+            val leader = newNode.promote()
+            val heartbeats = peers.map { peer -> Heartbeat( leader.address, peer, "0") }
+            //TODO most of the time when we have a call to the 'copy' method passing only one param, it is most likely we
+            //want to have a 'business' method as add().
+            //This would avoid bugs of passing the wrong values as in:
+            //leader.copy(sent = sent + heartbeats...) instead of leader.copy(sent = leader.sent + heartbeats....)
+            return leader.copy(sent = leader.sent + heartbeats.map { SentMessage(it, network.clock) }) to messagesToSend + heartbeats
         }
 
-        return this.copy(state = newState, received = messageLog, sent = newSent) to messagesToSend
+        return node to messagesToSend
     }
 
-    fun shouldBecomeLeader(messageLog: List<ReceivedMessage>): Boolean {
+    fun shouldBecomeLeader(): Boolean {
         //TODO + 1 represents the Vote for Self, do we want to add it to the MessageLogEntry and remove it from here
-        return messageLog.count { m -> m.message is VoteFromFollower } + 1 > clusterSize() / 2
+        return received.count { m -> m.message is VoteFromFollower } + 1 > clusterSize() / 2
     }
 
     // TODO We need to make sure that this Heartbeat comes from the real Leader (check term index?)
     //      and we aren't receiving Heartbeats from any other source
-    private fun shouldDemoteToFollower(messageLog: List<ReceivedMessage>): Boolean {
-        return messageLog.any { it.message is Heartbeat }
+    private fun shouldDemoteToFollower(): Boolean {
+        return received.any { it.message is Heartbeat }
     }
 
     private fun clusterSize(): Int  {
@@ -73,11 +77,11 @@ data class Candidate(
         TODO("Not yet implemented")
     }
 
-    private fun promote(newState: Int, newReceived: List<ReceivedMessage>, newSent: List<SentMessage>): Leader {
-        return Leader(this.address, this.name, newState, this.network, this.peers, newReceived, newSent, this.config)
+    private fun promote(): Leader {
+        return Leader(this.address, this.name, this.state, this.network, this.peers, this.received, this.sent, this.config)
     }
 
-    private fun demote(newState: Int, newReceived: List<ReceivedMessage>, newSent: List<SentMessage>): Follower {
-        return Follower(this.address, this.name, newState, this.network, this.peers, newReceived, newSent, this.config)
+    private fun demote(): Follower {
+        return Follower(this.address, this.name, this.state, this.network, this.peers, this.received, this.sent, this.config)
     }
 }

--- a/src/main/kotlin/Follower.kt
+++ b/src/main/kotlin/Follower.kt
@@ -13,12 +13,13 @@ data class Follower(
 
     override fun process(accumulatedToSend: List<Message>, received: Message): Pair<Node, List<Message>> {
         val (n, newToSend) =  when(received) {
-            is Heartbeat -> ((this.copy(state = state + received.content.toInt())) to accumulatedToSend)
-            is RequestForVotes -> (this to (if (shouldVote(accumulatedToSend)) accumulatedToSend + VoteFromFollower(address, Destination.from(received.src), "VOTE FROM FOLLOWER") else accumulatedToSend))
-            is VoteFromFollower -> (this to accumulatedToSend)
+            is Heartbeat -> ((this.copy(state = state + received.content.toInt())) to emptyList())
+            is RequestForVotes -> (this to (if (shouldVote(accumulatedToSend)) listOf(VoteFromFollower(address, Destination.from(received.src), "VOTE FROM FOLLOWER")) else emptyList()))
+            is VoteFromFollower -> (this to emptyList())
         }
 
-        return n to newToSend
+        val n2 = n.copy(received = n.received + ReceivedMessage(received, network.clock), sent = n.sent + newToSend.map { SentMessage(it, network.clock) } )
+        return n2 to accumulatedToSend + newToSend
     }
 
     override fun tick(): Node {
@@ -34,26 +35,22 @@ data class Follower(
             n.process(messages, msg)
         }
 
-        val messageLog = received + tickMessages.map { ReceivedMessage(it, network.clock) }
-        val newSent = sent + messagesToSend.map { SentMessage(it, network.clock) }
-
-        if (shouldPromote(messageLog)) {
-            // TODO when creating a candidate (promoting a follower), add a 'VoteFromFollower' from self to received messageLogMove this to a Candidate constructor that takes a Follower
-            val candidate = promote(messageLog, newSent)
-            peers.forEach { peer -> candidate.send(RequestForVotes(this.address, peer, "REQUEST FOR VOTES")) } // TODO Refactor to return the messages to be sent instead of a side effect
-            return candidate to messagesToSend
+        if ((node as Follower).shouldPromote()) {
+            // TODO when creating a candidate (promoting a follower), add a 'VoteFromFollower' from self to received messageLog. Move this to a Candidate constructor that takes a Follower
+            val candidate = node.promote()
+            val requestForVotes = peers.map { peer -> RequestForVotes(this.address, peer, "REQUEST FOR VOTES") }
+            return candidate.copy(sent = candidate.sent + requestForVotes.map { SentMessage(it, network.clock) }) to messagesToSend + requestForVotes
         }
 
-        //return node to messagesToSend
-        return n.copy(received = messageLog, sent = newSent) to messagesToSend
+        return node to messagesToSend
     }
 
     //TODO UNIT TEST
-    private fun shouldPromote(messageLog: List<ReceivedMessage>): Boolean {
+    private fun shouldPromote(): Boolean {
         // On system startup, Follower hasn't received any messages and should promote itself after electionTimeout
-        val hasReachedFirstTimeoutAfterStartup = messageLog.isEmpty() && network.clock > config.electionTimeout
+        val hasReachedFirstTimeoutAfterStartup = received.isEmpty() && network.clock > config.electionTimeout
         // During normal operation of the system, has not received messages in electionTimeout period
-        val hasReachedTimeoutWithLastMessage = messageLog.isNotEmpty() && network.clock - messageLog.last().receivedAt > config.electionTimeout
+        val hasReachedTimeoutWithLastMessage = received.isNotEmpty() && network.clock - received.last().receivedAt > config.electionTimeout
         return hasReachedTimeoutWithLastMessage || hasReachedFirstTimeoutAfterStartup
     }
 
@@ -66,7 +63,7 @@ data class Follower(
         return (sent + tickMessages).filterIsInstance<VoteFromFollower>().isEmpty()
     }
 
-    private fun promote(newReceived: List<ReceivedMessage>, newSent: List<SentMessage>): Candidate {
-        return Candidate(this.address, this.name, this.state, this.network, this.peers, newReceived, newSent)
+    private fun promote(): Candidate {
+        return Candidate(this.address, this.name, this.state, this.network, this.peers, this.received, this.sent)
     }
 }

--- a/src/main/kotlin/Node.kt
+++ b/src/main/kotlin/Node.kt
@@ -42,7 +42,7 @@ data class Heartbeat(override val src: Source, override val dest: Destination, o
 //data class AppendEntries(override val src: Address, override val dest: Address, override val content: String) : Message(src, dest, content)
 
 
-abstract class Node(
+sealed class Node(
     open val address: Address,
     open val name: String,
     open val state: Int,
@@ -57,6 +57,7 @@ abstract class Node(
     }
     abstract fun tick(): Node
     abstract fun tickWithoutSideEffects(): Pair<Node, List<Message>>
+    abstract fun process(toSend: List<Message>, received: Message): Pair<Node, List<Message>>
     abstract fun receive(message: Message): Node
     fun send(message: Message) {
         network.add(message)

--- a/src/test/kotlin/CandidateTest.kt
+++ b/src/test/kotlin/CandidateTest.kt
@@ -14,18 +14,19 @@ class CandidateTest {
     fun `Does not become a leader if it has not received Votes from the majority of the cluster`() {
         val candidate = candidate()
 
-        assertFalse(candidate.shouldBecomeLeader(emptyList()))
+        assertFalse(candidate.shouldBecomeLeader())
     }
 
     @Test
     fun `Becomes a leader if it has received Votes from the majority of the cluster`() {
-        val candidate = candidate()
-
         val messageLog = listOf(
             ReceivedMessage(VoteFromFollower(Source("host1", 1), Destination("host0", 1), "Vote"), 0),
             ReceivedMessage(VoteFromFollower(Source("host2", 1), Destination("host0", 1), "Vote"), 0),
         )
-        assertTrue(candidate.shouldBecomeLeader(messageLog))
+
+        val candidate = candidate().copy(received = messageLog)
+
+        assertTrue(candidate.shouldBecomeLeader())
     }
 
     fun candidate(): Candidate {

--- a/src/test/kotlin/FollowerTest.kt
+++ b/src/test/kotlin/FollowerTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 class FollowerTest {
     @Test
-    fun `Do not vote for more than one Candidate`() {
+    fun `After receiving Request For Votes from more than one candidate, responde with a Vote to only one of them`() {
         val network = Network(mapOf(Source("host", 1) to listOf(
             NetworkMessage(RequestForVotes(Source("host", 2), Destination("host", 1), "REQUEST FOR VOTES"), 0),
             NetworkMessage(RequestForVotes(Source("host", 3), Destination("host", 1), "REQUEST FOR VOTES"), 0)

--- a/src/test/kotlin/usecases/ElectionTest.kt
+++ b/src/test/kotlin/usecases/ElectionTest.kt
@@ -44,8 +44,9 @@ class ElectionTest {
         assertEquals("VOTE FROM FOLLOWER", leaderWithVote.received.first().message.content)
     }
 
+    //TODO use the assertIs idiomatic matchers
     @Test
-    fun `With 3 nodes, where 2 will promote to Candidate at the same tick, only one will receive a vote from the remaining Follower (and promote) the other will revert to Follower`() {
+    fun `With 3 nodes, where 2 will promote to Candidate at the same tick, only one will receive a vote from the remaining Follower (and promote), the other will revert to Follower`() {
         // Given
         val network = Network()
 
@@ -67,6 +68,9 @@ class ElectionTest {
         assertTrue(candidateWillLose is Candidate)
         assertTrue(follower is Follower)
 
+        // Make sure the Request For Votes arrived at the Follower
+
+        //TODO Make a assertion matcher to guarantee a node sent a message and it arrived on the other Node and write an ADR
         val futureWinnerRequestForVotes = follower.received.first().message
         assertTrue(futureWinnerRequestForVotes is RequestForVotes)
         assertEquals(willBecomeLeaderAddress, futureWinnerRequestForVotes.src)


### PR DESCRIPTION
Candidate, Follower and Leader return the new 'Node' after processing the incoming messages

The next step is to move the logic in 'tick' to its
appropriate pattern matchin in 'process'. For example, move the 'shouldBecomeLeader'
method in Candidate to the VoteFromFollower match in 'process'.

This allowed us to write a version of 'tick' without side effects: tickWithoutSideEffects.
We still might want to remove the side effects completely out of the Nodes.